### PR TITLE
Pv2 3885 complete collection periods from api/periodends

### DIFF
--- a/src/api/PeriodEnds_README.md
+++ b/src/api/PeriodEnds_README.md
@@ -1,6 +1,6 @@
 #�Period Ends API
 
-Period ends are a slow moving feed of items signifying a successful completion of a period end. With said feed only containing collection periods that have a status of completed or null.
+Period ends are a slow moving feed of items signifying a successful completion of a period end. With said feed only containing collection periods that have a status of completed or null (to cover historical records that are already complete but do not have a status). 
 
 ## Get period ends
 

--- a/src/api/PeriodEnds_README.md
+++ b/src/api/PeriodEnds_README.md
@@ -1,6 +1,6 @@
-# Period Ends API
+#ï¿½Period Ends API
 
-Period ends are a slow moving feed of items signifying a successful completion of a period end.
+Period ends are a slow moving feed of items signifying a successful completion of a period end. With said feed only containing collection periods that have a status of completed or null.
 
 ## Get period ends
 

--- a/src/api/SFA.DAS.Provider.Events.Infrastructure/Data/DcfsPeriodRepository.cs
+++ b/src/api/SFA.DAS.Provider.Events.Infrastructure/Data/DcfsPeriodRepository.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.Provider.Events.Infrastructure.Data
 
         public async Task<PeriodEntity[]> GetPeriods()
         {
-            var command = $"SELECT {Columns} FROM {Source} WHERE CollectionPeriodStatus = 4 ORDER BY CompletionDate";
+            var command = $"SELECT {Columns} FROM {Source} WHERE (Status = 4 or Status is null) ORDER BY CompletionDate";
             return await Query<PeriodEntity>(command).ConfigureAwait(false);
         }
 

--- a/src/api/SFA.DAS.Provider.Events.Infrastructure/Data/DcfsPeriodRepository.cs
+++ b/src/api/SFA.DAS.Provider.Events.Infrastructure/Data/DcfsPeriodRepository.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.Provider.Events.Infrastructure.Data
 
         public async Task<PeriodEntity[]> GetPeriods()
         {
-            var command = $"SELECT {Columns} FROM {Source} ORDER BY CompletionDate";
+            var command = $"SELECT {Columns} FROM {Source} WHERE CollectionPeriodStatus = 4 ORDER BY CompletionDate";
             return await Query<PeriodEntity>(command).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Adjusts the sql query for collection periods so that it only receives ones that have a completed or null status. Question for the future is if we need to add the status as a part of the collectionPeriod entity, however, given that we use it just for the initial filtering this seems unlikely